### PR TITLE
Add "Contact us" link to navigation

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ const { title } = Astro.props;
     <nav>
         <a href="/"> Home</a>
         <a href="/about"> About</a>
+        <a href="/about"> Contact us</a>
     </nav>
     <main>
         <slot />


### PR DESCRIPTION
This update adds a "Contact us" link to the navigation menu in the BaseLayout component. It ensures easier access to the contact page for users navigating the site.